### PR TITLE
feat: sticks navigation arrows to sides of carousel

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -54,6 +54,28 @@
       </template>
     </demo-snippet>
 
+    <h2>Carousel of auro-panes with sticky navigators</h2>
+    <demo-snippet>
+      <template>
+        <auro-carousel label="Flight options" displayArrows>
+          <auro-pane date="2020-10-10"></auro-pane>
+          <auro-pane date="2020-10-11"></auro-pane>
+          <auro-pane date="2020-10-12"></auro-pane>
+          <auro-pane date="2020-10-13" selected></auro-pane>
+          <auro-pane date="2020-10-14"></auro-pane>
+          <auro-pane date="2020-10-15"></auro-pane>
+          <auro-pane date="2020-10-16"></auro-pane>
+          <auro-pane date="2020-10-17"></auro-pane>
+          <auro-pane date="2020-10-18"></auro-pane>
+          <auro-pane date="2020-10-19"></auro-pane>
+          <auro-pane date="2020-10-16"></auro-pane>
+          <auro-pane date="2020-10-17"></auro-pane>
+          <auro-pane date="2020-10-18"></auro-pane>
+          <auro-pane date="2020-10-19"></auro-pane>
+        </auro-carousel>
+      </template>
+    </demo-snippet>
+
     <h2>Carousel of images</h2>
     <demo-snippet>
       <template>

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,10 +4,11 @@ auro-carousel displays a group of elements in a scrollable container.
 
 ## Properties
 
-| Property         | Attribute        | Type     | Default | Description                                      |
-|------------------|------------------|----------|---------|--------------------------------------------------|
-| `label`          | `label`          | `String` |         | The accessible name for the carousel. Logs a console warning if not set. |
-| `scrollDistance` | `scrollDistance` | `Number` | 300     | How many pixels to scroll the carousel when the shoulder buttons are triggered. |
+| Property         | Attribute        | Type      | Default | Description                                      |
+|------------------|------------------|-----------|---------|--------------------------------------------------|
+| `displayArrows`  | `displayArrows`  | `Boolean` |         | Forces left and right navigation to stick in DOM regardless of content width |
+| `label`          | `label`          | `String`  |         | The accessible name for the carousel. Logs a console warning if not set. |
+| `scrollDistance` | `scrollDistance` | `Number`  | 300     | How many pixels to scroll the carousel when the shoulder buttons are triggered. |
 
 ## Methods
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,6 +65,21 @@
         <img src="https://picsum.photos/200?random=12" alt="Random image 12">
         <img src="https://picsum.photos/200?random=13" alt="Random image 13">
       </auro-carousel>`
+      `<auro-carousel label="images" displayArrows>
+        <img src="https://picsum.photos/200?random=1" alt="Random image 1">
+        <img src="https://picsum.photos/200?random=2" alt="Random image 2">
+        <img src="https://picsum.photos/200?random=3" alt="Random image 3">
+        <img src="https://picsum.photos/200?random=4" alt="Random image 4">
+        <img src="https://picsum.photos/200?random=5" alt="Random image 5">
+        <img src="https://picsum.photos/200?random=6" alt="Random image 6">
+        <img src="https://picsum.photos/200?random=7" alt="Random image 7">
+        <img src="https://picsum.photos/200?random=8" alt="Random image 8">
+        <img src="https://picsum.photos/200?random=9" alt="Random image 9">
+        <img src="https://picsum.photos/200?random=10" alt="Random image 10">
+        <img src="https://picsum.photos/200?random=11" alt="Random image 11">
+        <img src="https://picsum.photos/200?random=12" alt="Random image 12">
+        <img src="https://picsum.photos/200?random=13" alt="Random image 13">
+      </auro-carousel>`
     ]
   </script>
 </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-carousel",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/auro-carousel.js
+++ b/src/auro-carousel.js
@@ -15,6 +15,7 @@ import "@alaskaairux/auro-icon";
 /**
  * auro-carousel displays a group of elements in a scrollable container.
  *
+ * @attr {Boolean} displayArrows - Forces left and right navigation to stick in DOM regardless of content width
  * @attr {Number} scrollDistance - How many pixels to scroll the carousel when the shoulder buttons are triggered.
  * @attr {String} label - The accessible name for the carousel. Logs a console warning if not set.
  *
@@ -41,6 +42,7 @@ class AuroCarousel extends LitElement {
 
   static get properties() {
     return {
+      displayArrows: {type: Boolean},
       scrollDistance: {
         type: Number,
         reflect: true
@@ -216,8 +218,8 @@ class AuroCarousel extends LitElement {
   render() {
     const carouselClassMap = {
       "carousel": true,
-      "carousel--scrolledToStart": this.scrolledToStart,
-      "carousel--scrolledToEnd": this.scrolledToEnd
+      "carousel--scrolledToStart": this.scrolledToStart && !this.displayArrows,
+      "carousel--scrolledToEnd": this.scrolledToEnd && !this.displayArrows
     }
 
     return html`

--- a/test/auro-carousel.test.js
+++ b/test/auro-carousel.test.js
@@ -26,6 +26,13 @@ describe('auro-carousel', () => {
     expect(el.carousel.getAttribute('aria-label')).to.equal('buttons');
   });
 
+  it('sticks the navigation arrows properly', async () => {
+    const el = await getDefaultFixture();
+    el.carousel.setAttribute('displayArrows', true);
+    expect(el.carousel.querySelector('.carousel--scrolledToStart')).to.equal(null);
+    expect(el.carousel.querySelector('.carousel--scrolledToEnd')).to.equal(null);
+  })
+
   it('scrolls the container right when right button clicked', async () => {
     const el = await getDefaultFixture();
     rightButton(el).click();


### PR DESCRIPTION
# Alaska Airlines Pull Request

For our Calendar Shoulder, we need the left and right navigators to always be displayed on the screen.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
