### PR TITLE
fix: increase gradient width

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -38,7 +38,8 @@
     &::before, &::after {
       content: '';
       height: 100%;
-      width: 6.5rem;
+      width: 8.75rem;
+      pointer-events: none;
       display: block;
       position: absolute;
       top: 50%;


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary:

Per @sryckman, the size of the gradients on either side has been increased to 140px.

I also disabled pointer events on the gradients so that clicks can pass through to whatever is underneath.

![image](https://user-images.githubusercontent.com/4992896/95884663-3ba28f80-0d31-11eb-85bb-9282ba54b37c.png)


## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
