### PR TITLE
fix: transformed child obscuring left toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-carousel",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/style.scss
+++ b/src/style.scss
@@ -121,6 +121,7 @@
     cursor: pointer;
     color: var(--auro-color-ui-default-on-light);
     padding: 0;
+    z-index: 1;
 
     &:hover {
       background: var(--auro-color-ui-default-on-light);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes https://github.com/AlaskaAirlines/auro-pane/issues/6

## Summary:

When `auro-pane` was placed in the carousel and selected, it would cover the left toggle. I bumped up the z-index to prevent this.

Before:
![carousel](https://user-images.githubusercontent.com/4992896/99738938-832ee080-2a80-11eb-81df-bddc8d5fe9f5.gif)

After:
![carousel2](https://user-images.githubusercontent.com/4992896/99738908-70b4a700-2a80-11eb-8612-c0018405d706.gif)

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
