### PR TITLE
AURO MIGRATION: Remove unused peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-carousel",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-carousel",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -64,10 +64,6 @@
       },
       "engines": {
         "node": "^20.x || ^22.x "
-      },
-      "peerDependencies": {
-        "@aurodesignsystem/design-tokens": "^4.13.0",
-        "@aurodesignsystem/webcorestylesheets": "^6.0.2"
       }
     },
     "node_modules/@alaskaairux/icons": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,6 @@
     "eslint": "^9.16.0",
     "lit": "^3.2.1"
   },
-  "peerDependencies": {
-    "@aurodesignsystem/design-tokens": "^4.13.0",
-    "@aurodesignsystem/webcorestylesheets": "^6.0.2"
-  },
   "devDependencies": {
     "@aurodesignsystem/design-tokens": "^4.13.0",
     "@aurodesignsystem/eslint-config": "^1.3.3",


### PR DESCRIPTION
Resolves AlaskaAirlines/auro-cli#37 by removing unused peer dependencies.

## Summary by Sourcery

Chores:
- Remove unused peer dependencies to reduce package size and potential conflicts.